### PR TITLE
Add render count limit

### DIFF
--- a/__tests__/middleware.js
+++ b/__tests__/middleware.js
@@ -1,8 +1,14 @@
 import sinon from 'sinon'
 import { types, addMiddleware, flow } from 'mobx-state-tree'
 import createMiddleware from '../src/middleware'
+import track from '../src/track'
 
-const mockAction = (opts) => Object.assign({ id: Date.now(), name: Date.now() }, opts)
+const mockAction = (opts) => Object.assign({ id: Date.now(), name: Date.now(), type: 'action' }, opts)
+const mockAsyncAction = (opts) => {
+  const name = Date.now()
+  return mockAction(Object.assign({ name, context: { $arboris: { [name]: { type: 'async' } } } }, opts))
+}
+
 const noop = () => {}
 const falseFn = () => false
 const trueFn = () => true
@@ -17,86 +23,121 @@ describe('middleware.js', () => {
     expect(middleware).toBeInstanceOf(Function)
   })
   
-  //describe('middleware function', () => {
-  //  it('adds id and name to tracker for flow_span action', () => {
-  //    const tracker = { add: sandbox.spy(), depthLimitReached: () => false }
-  //    const middleware = createMiddleware(tracker, console)
-  //    const action = mockAction({ type: 'flow_spawn' })
-  //
-  //    middleware(action, noop)
-  //    expect(tracker.add.calledWith(action.id, action.name)).toBe(true)
-  //  })
-  //
-  //  it('removes flow from tracker when it\' over', () => {
-  //    const tracker = {
-  //      has: trueFn,
-  //      remove: sandbox.spy(),
-  //      depthLimitReached: falseFn
-  //    }
-  //    const middleware = createMiddleware(tracker, console)
-  //    const action = mockAction({ type: 'flow_return' })
-  //
-  //    middleware(action, noop)
-  //    expect(tracker.remove.calledWith(action.id)).toBe(true)
-  //  })
-  //
-  //  it('removes flow from tracker when it fails', () => {
-  //    const tracker = {
-  //      has: trueFn,
-  //      remove: sandbox.spy(),
-  //      depthLimitReached: falseFn
-  //    }
-  //    const middleware = createMiddleware(tracker, console)
-  //    const action = mockAction({ type: 'flow_throw' })
-  //
-  //    middleware(action, noop)
-  //    expect(tracker.remove.calledWith(action.id)).toBe(true)
-  //  })
-  //
-  //  it('sends error to the logger if flow is missing from tracker', () => {
-  //    const tracker = {
-  //      has: falseFn,
-  //      depthLimitReached: falseFn
-  //    }
-  //    const logger = { error: sandbox.spy() }
-  //
-  //    const middleware = createMiddleware(tracker, logger)
-  //    const action = mockAction({ type: 'flow_return' })
-  //
-  //    middleware(action, noop)
-  //    expect(logger.error.calledOnce).toBe(true)
-  //  })
-  //
-  //  it('calls next function if depth limit has not been reached', () => {
-  //
-  //  })
-  //
-  //  it('does not call next function if depth limit has been reached', () => {
-  //
-  //  })
-  //
-  //  it('does not block non-flow functions if depth limit has been reached', () => {
-  //
-  //  })
-  //})
+  describe('middleware function', () => {
+   it('adds id and name to tracker for flow_span action', () => {
+     const tracker = { add: sandbox.spy(), renderLimitReached: falseFn }
+     const middleware = createMiddleware(tracker, console)
+     const action = mockAction({ type: 'flow_spawn' })
+
+     middleware(action, noop)
+     expect(tracker.add.calledWith(action.id, action.name)).toBe(true)
+   })
+
+   it('removes flow from tracker when it is over', () => {
+     const tracker = {
+       has: trueFn,
+       remove: sandbox.spy(),
+       renderLimitReached: falseFn
+     }
+     const middleware = createMiddleware(tracker, console)
+     const action = mockAction({ type: 'flow_return' })
+
+     middleware(action, noop)
+     expect(tracker.remove.calledWith(action.id)).toBe(true)
+   })
+
+   it('removes flow from tracker when it fails', () => {
+     const tracker = {
+       has: trueFn,
+       remove: sandbox.spy(),
+       renderLimitReached: falseFn
+     }
+     const middleware = createMiddleware(tracker, console)
+     const action = mockAction({ type: 'flow_throw' })
+
+     middleware(action, noop)
+     expect(tracker.remove.calledWith(action.id)).toBe(true)
+   })
+
+   it('sends error to the logger if flow is missing from tracker', () => {
+     const tracker = {
+       has: falseFn,
+       renderLimitReached: falseFn
+     }
+     const logger = { error: sandbox.spy() }
+
+     const middleware = createMiddleware(tracker, logger)
+     const action = mockAction({ type: 'flow_return' })
+
+     middleware(action, noop)
+     expect(logger.error.calledOnce).toBe(true)
+   })
+
+   it('calls next function if depth limit has not been reached', () => {
+     const tracker = {
+       has: trueFn,
+       add: noop,
+       renderLimitReached: falseFn
+     }
+     const next = sandbox.spy()
+
+     const middleware = createMiddleware(tracker, console)
+     const action = mockAsyncAction()
+
+     middleware(action, next)
+     expect(next.calledOnce).toBe(true)
+   })
+
+   it('does not call next function if depth limit has been reached', () => {
+     const tracker = {
+       has: trueFn,
+       add: noop,
+       renderLimitReached: trueFn
+     }
+     const next = sandbox.spy()
+
+     const middleware = createMiddleware(tracker, console)
+     const action = mockAsyncAction()
+
+     middleware(action, next)
+     expect(next.notCalled).toBe(true)
+   })
+
+   it('does not block non-flow functions if depth limit has been reached', () => {
+     const tracker = {
+       has: trueFn,
+       renderLimitReached: trueFn
+     }
+     const next = sandbox.spy()
+
+     const middleware = createMiddleware(tracker, console)
+     const action = mockAction({ type: 'action' })
+
+     middleware(action, next)
+     expect(next.calledOnce).toBe(true)
+   })
+  })
   
   it('within MST instance', async () => {
-    debugger;
     const delay = sandbox.stub().resolves(true)
-    const Store = types.model('Store')
-      .actions(self => ({
-        exampleFlow: flow(function* (args) {
-          yield delay()
-          return 2
-        })
-      }))
+    const Store = track(
+      types.model('Store')
+        .actions(() => ({
+          exampleFlow: flow(function* () {
+            yield delay()
+            return 2
+          })
+        })),
+      { exampleFlow: track.async() }
+    )
+
     const store = Store.create()
   
     const tracker = {
       add: sandbox.spy(),
       has: trueFn,
       remove: sandbox.spy(),
-      depthLimitReached: falseFn
+      renderLimitReached: falseFn
     }
   
     const middleware = createMiddleware(tracker, console)
@@ -104,31 +145,6 @@ describe('middleware.js', () => {
     addMiddleware(store, middleware)
     
     const foo = await store.exampleFlow()
-    console.log(foo)
     expect(foo).toBe(2)
   })
 })
-
-//
-//export default function createMiddleware(tracker) {
-//  return function (call, next) {
-//    if(call.type === 'flow_spawn') {
-//      tracker.add(call.id, call.name)
-//    }
-//
-//    if(call.type === 'flow_return' || call.type === 'flow_throw') {
-//      if(!tracker.has(call.id)) {
-//        console.error(
-//          "[arboris] Could not find flow " + call.name + " (" + call.type + ").\n" +
-//          "Make sure you're applying Arboris middleware before running any actions."
-//        )
-//      } else {
-//        tracker.remove(call.id)
-//      }
-//    }
-//
-//    if(!tracker.depthLimitReached()) {
-//      return next(call);
-//    }
-//  }
-//}

--- a/__tests__/tracker.js
+++ b/__tests__/tracker.js
@@ -1,0 +1,121 @@
+import Tracker from '../src/tracker'
+import { makePromise } from '../src/utils'
+import sinon from 'sinon'
+
+const fn = () => {}
+const name = Date.now()
+
+const sandbox = sinon.createSandbox()
+const newTracker = ({ renderLimit = 10, timeout = 25000, logger = console } = {}) =>
+  new Tracker(renderLimit, timeout, true, logger)
+
+describe('tracker.js', () => {
+  afterEach(() => sandbox.restore())
+
+  it('adds call to collection', () => {
+    const tracker = newTracker()
+
+    tracker.add(fn, name)
+
+    expect(tracker.collection.size).toBe(1)
+  })
+
+  it('adds unlabeled call to collection', () => {
+    const tracker = newTracker()
+
+    tracker.add(fn)
+
+    expect(tracker.collection.values().next().value).toBe(fn.name)
+    expect(tracker.collection.size).toBe(1)
+  })
+
+  it('adds unlabeled ananymous function as a call to collection', () => {
+    const tracker = newTracker()
+
+    tracker.add(() => {})
+
+    expect(tracker.collection.values().next().value).toBe('() => {}')
+    expect(tracker.collection.size).toBe(1)
+  })
+
+  it('removes call from collection if there is one', () => {
+    const tracker = newTracker()
+
+    tracker.collection.set(fn, name)
+
+    expect(tracker.collection.size).toBe(1)
+
+    tracker.remove(fn)
+
+    expect(tracker.collection.size).toBe(0)
+  })
+
+  it('resolves the promise if there is no more calls to remove', () => {
+    const tracker = newTracker()
+    tracker.promise = makePromise()
+    tracker.promise.resolve = sandbox.spy()
+
+    expect(tracker.collection.size).toBe(0)
+
+    tracker.remove(fn)
+
+    expect(tracker.promise.resolve.calledOnce).toBe(true)
+  })
+
+  it('checks if call is in collection', () => {
+    const tracker = newTracker()
+    tracker.collection.set(fn, name)
+
+    expect(tracker.has(fn)).toBe(true)
+  })
+
+  it('successfully waits for render loop to finish on first pass', async () => {
+    const logger = { error: sandbox.spy() }
+    const tracker = newTracker({ logger })
+    tracker.add(fn)
+    const renderMethod = () => {
+      tracker.remove(fn)
+      return '<div>success</div>'
+    }
+
+    const result = await tracker.wait(renderMethod)
+
+    expect(result).toBe('<div>success</div>')
+    expect(tracker.depthLevel).toBe(1)
+    expect(logger.error.notCalled).toBe(true)
+  })
+
+  it('increases depth limit when there are unfinished flows after render', async () => {
+    const logger = { error: sandbox.spy() }
+    const tracker = newTracker({ logger })
+    tracker.add(fn)
+    const renderMethod = () => { setTimeout(() => tracker.remove(fn), 500) }
+
+    await tracker.wait(renderMethod)
+
+    expect(tracker.depthLevel).toBe(2)
+    expect(logger.error.notCalled).toBe(true)
+  })
+
+  it('stops waiting for render loop when timeout is reached', async () => {
+    const logger = { error: sandbox.spy() }
+    const tracker = newTracker({ timeout: 500, logger })
+    tracker.add(fn)
+    const renderMethod = () => { setTimeout(() => tracker.remove(fn), 1000) }
+
+    await tracker.wait(renderMethod)
+
+    expect(logger.error.called).toBe(true)
+  })
+
+  it('stops waiting for render loop when render limit is reached', async () => {
+    const logger = { warn: sandbox.spy() }
+    const tracker = newTracker({ renderLimit: 1, logger })
+    tracker.add(fn)
+    const renderMethod = () => { setTimeout(() => tracker.remove(fn), 500) }
+
+    await tracker.wait(renderMethod)
+
+    expect(logger.warn.calledOnce).toBe(true)
+  })
+})

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,0 +1,17 @@
+import {makePromise} from '../src/utils'
+
+describe('makePromise', () => {
+  it('returns a promise with accessible resolve function', () => {
+    const promise = makePromise()
+
+    expect(promise).toBeInstanceOf(Promise)
+    expect(promise.resolve).toBeInstanceOf(Function)
+  })
+
+  it('returns a promise with accessible reject function', () => {
+    const promise = makePromise()
+
+    expect(promise).toBeInstanceOf(Promise)
+    expect(promise.reject).toBeInstanceOf(Function)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "scripts": {
     "prepare": "webpack",
-    "test": "jest"
+    "test": "jest",
+    "test-debug": "node --inspect-brk ./node_modules/.bin/jest -i"
   },
   "jest": {
     "transform": {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,6 +1,11 @@
 export default function createMiddleware(tracker, logger) {
   return function (call, next) {
-    console.log(call)
+    const opts = ((call.context && call.context.$arboris) || {})[call.name]
+
+    if(opts && opts.type === 'async' && tracker.renderLimitReached()) {
+      return false
+    }
+
     if(call.type === 'flow_spawn') {
       tracker.add(call.id, call.name)
     }
@@ -16,8 +21,6 @@ export default function createMiddleware(tracker, logger) {
       }
     }
 
-    if(call.type === 'action' || !tracker.depthLimitReached()) {
-      return next(call);
-    }
+    return next(call)
   }
 }

--- a/src/track.js
+++ b/src/track.js
@@ -1,0 +1,9 @@
+const track = (model, config) => {
+  return model.volatile(() => ({
+    $arboris: config
+  }))
+}
+
+track.async = (opts = {}) => Object.assign({}, { type: 'async' }, opts)
+
+export default track

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 export function makePromise() {
-  let resolve, reject;
+  let resolve, reject
   const promise = new Promise(function(resolveFn, rejectFn) {
     resolve = resolveFn
     reject = rejectFn


### PR DESCRIPTION
Now, Arboris allows multiple render passes, so it's possible to wait for multiple async flows, spanning across multiple rerenders to finish themselves properly.